### PR TITLE
Adds a default CWE rule as fall back.

### DIFF
--- a/scanners/boostsecurityio/mitre-cwe/rules.yaml
+++ b/scanners/boostsecurityio/mitre-cwe/rules.yaml
@@ -10206,3 +10206,13 @@ rules:
     name: CWE-99
     pretty_name: 'CWE-99: Improper Control of Resource Identifiers (''Resource Injection'')'
     ref: https://cwe.mitre.org/data/definitions/99.html
+default:
+  CWE-UNKNOWN:
+    categories:
+    - ALL
+    - boost-hardened
+    group: top10-insecure-design
+    name: CWE-UNKNOWN
+    pretty_name: CWE-UNKNOWN - Original rule did not map to a known CWE rule
+    description: The original rule could not be map to a CWE rule
+    ref: https://cwe.mitre.org/data/index.html


### PR DESCRIPTION
In order to remove the need for a long list of allowed ids in converter, the default CWE is added to the rules db.