### PR TITLE
Adds CWE-919 rule to the mitre list.

### DIFF
--- a/scanners/boostsecurityio/mitre-cwe/rules.yaml
+++ b/scanners/boostsecurityio/mitre-cwe/rules.yaml
@@ -9970,6 +9970,18 @@ rules:
     name: CWE-918
     pretty_name: 'CWE-918: Server-Side Request Forgery (SSRF)'
     ref: https://cwe.mitre.org/data/definitions/918.html
+  CWE-919:
+    categories:
+    - ALL
+    - cwe-top-25
+    - boost-baseline
+    - boost-hardened
+    - owasp-top-10
+    group: top10-insecure-design
+    name: CWE-919
+    pretty_name: CWE-919 - Weaknesses in Mobile Applications
+    description: The code introduces a vulnerability in the mobile application.
+    ref: https://cwe.mitre.org/data/definitions/919.html
   CWE-920:
     categories:
     - ALL


### PR DESCRIPTION
CWE-919 is related to mobile application weaknesses. It has been added to the mobsfscan scanner's rules db. Given we want the scanner to move to the curated CWE rules db, adding the rule here too.