### PR TITLE
chore: upgraded scanner-registry-action to v1.1.0

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Scan Registry
-        uses: boostsecurityio/scanner-registry-action@a4bf60accc5416d6059860c707b352325e428bb8
+        uses: boostsecurityio/scanner-registry-action@v1.1.0
         with:
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY_PROD }}


### PR DESCRIPTION
Upgraded GitHub action scanner-registry-action to [v1.1.0](https://github.com/boostsecurityio/scanner-registry-action/releases/tag/v1.1.0).