### PR TITLE
BST-5970: Remove scan-types for server-side scanners

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Scan Registry
-        uses: boostsecurityio/scanner-registry-action@46e7400ddf34338f35563f6b9d357c03d315d674 # v1.4.0
+        uses: boostsecurityio/scanner-registry-action@ccc03dc7151b965babea65bfde96c7d088231881 # v1.5.0
         with:
           api_endpoint: ${{ vars.BOOST_API_ENDPOINT }}
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY }}

--- a/server-side-scanners/boostsecurityio/cicd/module.yaml
+++ b/server-side-scanners/boostsecurityio/cicd/module.yaml
@@ -1,4 +1,2 @@
 name: BoostSecurity CI/CD
 namespace: boostsecurityio/cicd
-scan_types:
-  - cicd

--- a/server-side-scanners/boostsecurityio/dependabot/module.yaml
+++ b/server-side-scanners/boostsecurityio/dependabot/module.yaml
@@ -1,4 +1,2 @@
 name: Dependabot
 namespace: boostsecurityio/dependabot
-scan_types:
-  - sca


### PR DESCRIPTION
Scan types for server-side scanners are defined in the backend, having them in the module file is not needed.