### PR TITLE
update boostsecurityio/semgrep

### DIFF
--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -15,8 +15,8 @@ steps:
   - scan:
       command:
         docker:
-          image: returntocorp/semgrep:1.27.0@sha256:7026020ebb6c1aa477431a2ba550df3ae4d080822e391d03bb816eeac700a36b
-          command: semgrep scan --sarif --quiet --disable-version-check
+          image: returntocorp/semgrep:1.39.0@sha256:fd3d6ccd390677db83880d99a9f494500c003ec82177cc141f6ec37f71633a96
+          command: semgrep scan --sarif --quiet --disable-version-check .
           workdir: /src
           environment:
             XDG_CONFIG_HOME: /tmp


### PR DESCRIPTION
- Update semgrep to 1.39.0
- BST-7784 - Fix modules to properly support monorepo