### PR TITLE
Revert "BST-10988: bump version of trivy to 0.51.4 (#125)"

### DIFF
--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -13,11 +13,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.51.4
-      LINUX_X86_64_SHA: eee127e93ed40e8f1c7bc2baa062a2635b01346a287046207d186c14b7a33af3
-      LINUX_ARM64_SHA: 9f8662f99478e4e13f4f20acaabd148057e60f8b7d886d7bb54bacf9793865df
-      MACOS_X86_64_SHA: 9c04716f984308798f04292c692d8dde6d0a719dd518459538eac11fd8ea6daa
-      MACOS_ARM64_SHA: d46302eb3545b04ae8684a0f5f29d6e108ae45e094189c2e4353626f0bf1b8c6
+      VERSION: 0.42.1
+      LINUX_X86_64_SHA: 305a4c6dbde3abac8e103376021e82c464478f829442e39a0fd980a77946bb22
+      LINUX_ARM64_SHA: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
+      MACOS_X86_64_SHA: a13af5f4d04b10ba181b12cc86f8735e441ab8eca7b6d23692b5061ae767411e
+      MACOS_ARM64_SHA: cebe7abc5d427f7bdedb506c2ae9b33259812ec5a779901b34efbac41bba572a
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)

--- a/scanners/boostsecurityio/trivy-sbom-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom-image/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.51.4
-      LINUX_X86_64_SHA: eee127e93ed40e8f1c7bc2baa062a2635b01346a287046207d186c14b7a33af3
-      LINUX_ARM64_SHA: 9f8662f99478e4e13f4f20acaabd148057e60f8b7d886d7bb54bacf9793865df
-      MACOS_X86_64_SHA: 9c04716f984308798f04292c692d8dde6d0a719dd518459538eac11fd8ea6daa
-      MACOS_ARM64_SHA: d46302eb3545b04ae8684a0f5f29d6e108ae45e094189c2e4353626f0bf1b8c6
+      VERSION: 0.42.1
+      LINUX_X86_64_SHA: 305a4c6dbde3abac8e103376021e82c464478f829442e39a0fd980a77946bb22
+      LINUX_ARM64_SHA: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
+      MACOS_X86_64_SHA: a13af5f4d04b10ba181b12cc86f8735e441ab8eca7b6d23692b5061ae767411e
+      MACOS_ARM64_SHA: cebe7abc5d427f7bdedb506c2ae9b33259812ec5a779901b34efbac41bba572a
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -12,11 +12,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.51.4
-      LINUX_X86_64_SHA: eee127e93ed40e8f1c7bc2baa062a2635b01346a287046207d186c14b7a33af3
-      LINUX_ARM64_SHA: 9f8662f99478e4e13f4f20acaabd148057e60f8b7d886d7bb54bacf9793865df
-      MACOS_X86_64_SHA: 9c04716f984308798f04292c692d8dde6d0a719dd518459538eac11fd8ea6daa
-      MACOS_ARM64_SHA: d46302eb3545b04ae8684a0f5f29d6e108ae45e094189c2e4353626f0bf1b8c6
+      VERSION: 0.42.1
+      LINUX_X86_64_SHA: 305a4c6dbde3abac8e103376021e82c464478f829442e39a0fd980a77946bb22
+      LINUX_ARM64_SHA: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
+      MACOS_X86_64_SHA: a13af5f4d04b10ba181b12cc86f8735e441ab8eca7b6d23692b5061ae767411e
+      MACOS_ARM64_SHA: cebe7abc5d427f7bdedb506c2ae9b33259812ec5a779901b34efbac41bba572a
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)


### PR DESCRIPTION
This reverts commit 3b21102e6ae958dd86158930d4543ce19bfab7d1.

There seems to be an issue that requires more investigation