### PR TITLE
BST-11165: add license type & rule to boost-sca

### DIFF
--- a/server-side-scanners/boostsecurityio/sbom-sca/module.yaml
+++ b/server-side-scanners/boostsecurityio/sbom-sca/module.yaml
@@ -2,3 +2,4 @@ name: BoostSecurity SBOM SCA
 namespace: boostsecurityio/sbom-sca
 scan_types:
   - sca
+  - license

--- a/server-side-scanners/boostsecurityio/sbom-sca/rules.yaml
+++ b/server-side-scanners/boostsecurityio/sbom-sca/rules.yaml
@@ -15,3 +15,13 @@ rules:
     group: top10-vulnerable-components
     pretty_name: Dependency with known malicious behaviour
     ref: https://github.com/ossf/malicious-packages/tree/main/osv/malicious
+  forbidden-license:
+    categories:
+      - ALL
+      - boost-baseline
+      - use-of-forbidden-license
+    description: Package with Unauthorized License
+    name: forbidden-license
+    group: license-violations
+    pretty_name: Package with Unauthorized License
+    ref: https://docs.boostsecurity.io/rules/index.html


### PR DESCRIPTION
This scanner can emit license finding. As such, it should be marked as a license scanner and have the rule for forbidden license usage.