### PR TITLE
BST-11165: add license type & rule to boost-sca

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   contents: read
-  
+
 jobs:
   scan_job:
     name: Scanner Registry Action
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Scan Registry
-        uses: boostsecurityio/scanner-registry-action@bcec6e2aedd41802de36511587d46e2eb47e8805 # v1.5.3
+        uses: boostsecurityio/scanner-registry-action@7c3690aed2453f790be130a209d644c41b333fb7 # v1.5.4
         with:
           api_endpoint: ${{ vars.BOOST_API_ENDPOINT }}
           api_token: ${{ secrets.BOOST_SYSTEM_API_KEY_REGISTRY }}

--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -5,6 +5,7 @@ name: BoostSecurity SCA
 namespace: boostsecurityio/boost-sca
 scan_types:
   - sca
+  - license
 
 config:
   require_full_repo: true

--- a/scanners/boostsecurityio/boost-sca/rules.yaml
+++ b/scanners/boostsecurityio/boost-sca/rules.yaml
@@ -1,5 +1,6 @@
 import:
   - boostsecurityio/sca-cve
+  - boostsecurityio/oss-license
 
 rules:
   dependency-with-malicious-behaviour:

--- a/scanners/boostsecurityio/boost-sca/rules.yaml
+++ b/scanners/boostsecurityio/boost-sca/rules.yaml
@@ -1,18 +1,3 @@
 import:
-  - boostsecurityio/sca-cve
+  - boostsecurityio/sbom-sca
   - boostsecurityio/oss-license
-
-rules:
-  dependency-with-malicious-behaviour:
-    categories:
-      - ALL
-      - boost-baseline
-      - boost-hardened
-      - supply-chain
-      - vulnerable-and-outdated-components
-      - dependency-with-malicious-behaviour
-    description: The dependency has been identified by the community to have malicious behaviour.
-    name: dependency-with-malicious-behaviour
-    group: top10-vulnerable-components
-    pretty_name: Dependency with known malicious behaviour
-    ref: https://github.com/ossf/malicious-packages/tree/main/osv/malicious

--- a/scanners/boostsecurityio/osv-scanner/module.yaml
+++ b/scanners/boostsecurityio/osv-scanner/module.yaml
@@ -84,7 +84,7 @@ steps:
     format: sarif
     post-processor:
       docker:
-          image: public.ecr.aws/boostsecurityio/boost-converter-sca:3fd32ff@sha256:f21a1539e5ed32f2cb97ee7048ec9ca825b491bfbfd86d1ac6f324cc04b5e9f4
+          image: public.ecr.aws/boostsecurityio/boost-converter-sca:af34fec@sha256:3d3ef2564450ffb4b79a7f88a92b36137fd7ea191ac521bba257d33ac011028d
           command: process --scanner osv
           environment:
               PYTHONIOENCODING: utf-8


### PR DESCRIPTION
- Adds the `license` scan type to the _boostsecurityio/boost-sca_ analyzer. 
- Update the registry action to the latest version to allow imports from server-side analyzers
- Update _boostsecurityio/boost-sca_ rules to imports from both _boostsecurityio/oss-license_ & _boostsecurityio/sbom-sca_