### PR TITLE
[BST-12209] Updates scanners for AI labels

### DIFF
--- a/scanners/boostsecurityio/modelscan/rules.yaml
+++ b/scanners/boostsecurityio/modelscan/rules.yaml
@@ -6,7 +6,7 @@ rules:
       - boost-hardened
       - supply-chain
       - vulnerable-and-outdated-components
-      - dependency-with-malicious-behaviour
+      - ai-model-with-malicious-behaviour
     description: The serialized AI model potentially has has malicious behavior given that it overrides the deserialization procedure in a way that could lead to arbitrary code execution.
     name: serialized-ai-model-with-malicious-behavior
     group: top10-vulnerable-components

--- a/server-side-scanners/boostsecurityio/sci-sca/rules.yaml
+++ b/server-side-scanners/boostsecurityio/sci-sca/rules.yaml
@@ -1,4 +1,18 @@
 import:
   - boostsecurityio/sca-cve
 
-rules: {}
+rules:
+  use-of-unsafe-ai-model:
+    categories:
+      - ALL
+      - boost-baseline
+      - boost-hardened
+      - supply-chain
+      - owasp-top-10
+      - unsafe-ai-component
+    description: An Unsafe AI model is being loaded. There are dangerous arbitrary code execution attacks that can be perpetrated when you load an unsafe AI model.
+    name: use-of-unsafe-ai-model
+    group: top10-vulnerable-components
+    pretty_name: Use of Unsafe AI model
+    ref: https://huggingface.co/docs/hub/en/security-pickle
+    recommended: true


### PR DESCRIPTION
Updates the sca from sci server side scanner to add a AI component specific rule, as well as modelscan rulesdb to include AI specific labels.