### PR TITLE
Updates the Boost SCA scanner version of Trivy to 0.54.1

### DIFF
--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -14,11 +14,11 @@ config:
 setup:
   - name: download trivy
     environment:
-      VERSION: 0.51.4
-      LINUX_X86_64_SHA: eee127e93ed40e8f1c7bc2baa062a2635b01346a287046207d186c14b7a33af3
-      LINUX_ARM64_SHA: 9f8662f99478e4e13f4f20acaabd148057e60f8b7d886d7bb54bacf9793865df
-      MACOS_X86_64_SHA: 9c04716f984308798f04292c692d8dde6d0a719dd518459538eac11fd8ea6daa
-      MACOS_ARM64_SHA: d46302eb3545b04ae8684a0f5f29d6e108ae45e094189c2e4353626f0bf1b8c6
+      VERSION: 0.54.1
+      LINUX_X86_64_SHA: bbaaf8278b2a9bb49aa848fe23c8bfe19f7db4f5dc7b55a9793357cd78cb5ec5
+      LINUX_ARM64_SHA: 26f8ee5a44ca027082c426d982ce95a37b88cf66defa1e982641eb4497bf1e99
+      MACOS_X86_64_SHA: d182c2de5496504120269b8d50b543e88b4837f8c9876055e54248f0a4e93d77
+      MACOS_ARM64_SHA: 0ea077b074e38c3bce419d3cfaa417581c36e985beb9e571c06c01293158ff6f
     run: |
       BINARY_URL="https://github.com/aquasecurity/trivy/releases/download/v${VERSION}"
       ARCH=$(uname -m)


### PR DESCRIPTION
Some failures where experienced with Trivy scanner 0.51, updating to latest (0.54.1) to see if it fixes it.

Tests were ran on dev-registry with module test and independent repositories. 