### PR TITLE
Update Semgrep and migrate to Boost rules, instead of Community Rules

### DIFF
--- a/scanners/boostsecurityio/semgrep-pro/module.yaml
+++ b/scanners/boostsecurityio/semgrep-pro/module.yaml
@@ -29,7 +29,7 @@ steps:
   - scan:
       command:
         docker:
-          image: returntocorp/semgrep:1.103.0@sha256:3978a2b4e6c2cbd4eee04b0f05d5ca4a82e6526dc89e01a5dcbb941cedafb393
+          image: returntocorp/semgrep:1.114.0@sha256:0cd75960cfec2215ff734a4f6379bbbb6edb82de0c24593dd0a70ec65e9860a9
           command: semgrep scan --pro-intrafile --sarif --quiet --disable-version-check .
           workdir: /src
           environment:

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -12,23 +12,34 @@ config:
   - .semgrep/*
 
 setup:
-  - name: Config
+  - name: Validate rules
     environment:
-      SEMGREP_RULES: ${SEMGREP_RULES:-auto}
+      SEMGREP_RULES: ${SEMGREP_RULES:-https://assets.build.boostsecurity.io/semgrep-rules/stable/all-sast-rules.yml}
     run: |
-      echo "SEMGREP_RULES: '$SEMGREP_RULES'"
+      echo "SEMGREP_RULES set to: '$SEMGREP_RULES'"
+      for rule in $SEMGREP_RULES; do
+        case "$rule" in
+          .semgrep/*|http://*|https://*)
+            # valid rule token; do nothing
+            ;;
+          *)
+            echo "Semgrep Community Rules cannot be used. Provide a URL or relative path to rules file or leave blank for Boost curated rules."
+            exit 1
+            ;;
+        esac
+      done
 
 steps:
   - scan:
       command:
         docker:
-          image: returntocorp/semgrep:1.103.0@sha256:3978a2b4e6c2cbd4eee04b0f05d5ca4a82e6526dc89e01a5dcbb941cedafb393
-          command: semgrep scan --oss-only --sarif --quiet --disable-version-check .
+          image: returntocorp/semgrep:1.114.0@sha256:0cd75960cfec2215ff734a4f6379bbbb6edb82de0c24593dd0a70ec65e9860a9
+          command: semgrep scan --oss-only --sarif --quiet --disable-version-check --metrics=off .
           workdir: /src
           environment:
             XDG_CONFIG_HOME: /tmp
             HOME: /tmp
-            SEMGREP_RULES: ${SEMGREP_RULES:-auto}
+            SEMGREP_RULES: ${SEMGREP_RULES:-https://assets.build.boostsecurity.io/semgrep-rules/stable/all-sast-rules.yml}
       format: sarif
       post-processor:
         docker:


### PR DESCRIPTION
This is a hard cutover, preventing from using Semgrep servers (except for Semgrep Pro)