### PR TITLE
[BST-14587] Update sbom-sca with new end-of-life rule

### DIFF
--- a/server-side-scanners/boostsecurityio/sbom-sca/rules.yaml
+++ b/server-side-scanners/boostsecurityio/sbom-sca/rules.yaml
@@ -16,3 +16,19 @@ rules:
     pretty_name: Dependency with known malicious behaviour
     ref: https://github.com/ossf/malicious-packages/tree/main/osv/malicious
     recommended: true
+  
+  end-of-life-not-maintained:
+    categories:
+      - ALL
+      - boost-baseline
+      - boost-hardened
+      - supply-chain
+      - vulnerable-and-outdated-components
+    description: This package has reached its end-of-life (EOL), meaning it is no longer maintained or supported by its maintainers. 
+      EOL packages do not receive security updates, bug fixes, or performance improvements, making them a significant risk if vulnerabilities are discovered. 
+      It is strongly recommended to upgrade to a supported version or migrate to an alternative maintained package to ensure continued security and stability of your application.
+    name: end-of-life-not-maintained
+    group: top10-vulnerable-components
+    pretty_name: The Package Reached End of Life (EOL).
+    ref: https://docs.boostsecurity.io/rules/index.html
+    recommended: true


### PR DESCRIPTION
* We recently added `end_of_life` info to know when a package is end_of_life in sbom.