### PR TITLE
[NATIVE-SCANNER] BST-19755: support detecting more lockfile types

### DIFF
--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -41,7 +41,7 @@ steps:
     - scan:
         command:
           docker:
-            image: public.ecr.aws/boostsecurityio/boost-scanner-native:576779b@sha256:ba38797b76a669bcbd9d1f4d50c49ddbd0f375d906a26a9396a6825eae458eaf
+            image: public.ecr.aws/boostsecurityio/boost-scanner-native:6b6cf90@sha256:285e3bd9b11cf47c5e28d501eca0dd70a139f8c02ec1d9a469ba69d3d77dd8f9
             command: scanner scan
             workdir: /src
           name: scanner

--- a/scanners/boostsecurityio/scanner/tests.yaml
+++ b/scanners/boostsecurityio/scanner/tests.yaml
@@ -20,3 +20,8 @@ tests:
     source:
       url: "https://github.com/NeuraLegion/brokencrystals.git"
       ref: "stable"
+  - name: "cicd-no-unpinned-deps"
+    type: "source-code"
+    source:
+      url: "https://github.com/boost-sandbox/cicd-no-unpinned-deps.git"
+      ref: "main"


### PR DESCRIPTION
this PR bumps the base image for the native/baseline scanner to include detection of more lock file types

some customers used newer lockfiles types that we didn't support yet, so we falsely reported missing lockfiles