### PR TITLE
BST-20065: use forked version of checkov that fixes infinite hang

### DIFF
--- a/scanners/boostsecurityio/checkov-tf-plan/module.yaml
+++ b/scanners/boostsecurityio/checkov-tf-plan/module.yaml
@@ -14,7 +14,7 @@ steps:
   - scan:
       command:
         docker:
-          image: 289082777815.dkr.ecr.us-east-2.amazonaws.com/docker/bridgecrew/checkov:3.2.495@sha256:4c2c3b67f09867ef2843a03d8ba82adf712eb93ea3584c1708c24ed584f6da17
+          image: public.ecr.aws/boostsecurityio/checkov:388e194@sha256:237833f0cff6e0ae2e89cb1331d43c173f12770736f55c4ad19aa99bef98fa12
           command: --file ./boost.tfplan.json --output json --soft-fail --compact --skip-download --framework terraform_plan
           workdir: /src
       format: sarif

--- a/scanners/boostsecurityio/checkov/module.yaml
+++ b/scanners/boostsecurityio/checkov/module.yaml
@@ -14,7 +14,7 @@ steps:
   - scan:
       command:
         docker:
-          image: 289082777815.dkr.ecr.us-east-2.amazonaws.com/docker/bridgecrew/checkov:3.2.495@sha256:4c2c3b67f09867ef2843a03d8ba82adf712eb93ea3584c1708c24ed584f6da17
+          image: public.ecr.aws/boostsecurityio/checkov:388e194@sha256:237833f0cff6e0ae2e89cb1331d43c173f12770736f55c4ad19aa99bef98fa12
           command: --directory . --output json --soft-fail --quiet --skip-download --skip-framework secrets
           workdir: /src
       format: sarif


### PR DESCRIPTION
# Changelog

## checkov/checkov-tf-plan
* fix for infinite hang when a child process dies
  * We forked checkov and overhauled the child process management

- [x] scanner tests pass on all ci providers
- [x] scanner produces the same findings as the current version of checkov
- [x] customer verified this no longer causes a hang