### PR TITLE
BST-20363 Fix codeql download extraction

### DIFF
--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -35,7 +35,7 @@ setup:
       curl -fsSL -O https://assets.build.boostsecurity.io/scanners/codeql/codeql-2.17.2/linux/amd64/codeql.tar.gz
             echo "0f82b9b22f9d3f9e7a9ac0f6cccc8ac30dc10cc0eff7935682223ee4ff8c156d  codeql.tar.gz" | sha256sum --check
 
-      tar -xzf codeql-bundle-linux64.tar.gz
+      tar -xzf codeql.tar.gz
 
 steps:
   - name: "Create CodeQL database"

--- a/scanners/boostsecurityio/codeql/tests.yaml
+++ b/scanners/boostsecurityio/codeql/tests.yaml
@@ -1,0 +1,9 @@
+version: "1.0"
+tests:
+  - name: "railsgoat"
+    type: "source-code"
+    source:
+      url: "https://github.com/owasp/railsgoat.git"
+      ref: "main"
+    env:
+      CODEQL_LANGUAGE: "ruby"


### PR DESCRIPTION
The previous CodeQL artifact vendoring changed the name of the file being downloaded, but not the file extracted.

This is changing the file extracted and adding a test, now that we support env vars.