### PR TITLE
fix: route failing scanner commands to stderr

### DIFF
--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -111,8 +111,10 @@ steps:
                                --skip-version-check \
                                . 2>"$LOG"
           ec=$?
-          cat "$LOG"
-          cat "$LOG" >&2
+          # trivy's logs carry the "no language files" signal AND its fatal errors;
+          # both readers consume a different stream, so emit the logs to each:
+          cat "$LOG"      # stdout: the post-processor reads the "no language files" count here
+          cat "$LOG" >&2  # stderr: the CLI's failure telemetry only reads stderr, so errors surface
           exit "$ec"
       format: cyclonedx
       post-processor:

--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -107,8 +107,8 @@ steps:
           --license-full
           --no-progress
           --scanners vuln
-          --skip-version-check 
-          . 2>&1
+          --skip-version-check
+          .
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/boost-sca/module.yaml
+++ b/scanners/boostsecurityio/boost-sca/module.yaml
@@ -100,15 +100,20 @@ steps:
           TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
-        run: >
-          $SETUP_PATH/trivy fs 
-          --cache-dir=/tmp/trivy/
-          --format=cyclonedx
-          --license-full
-          --no-progress
-          --scanners vuln
-          --skip-version-check
-          .
+        run: |
+          set +e
+          LOG=$(mktemp)
+          $SETUP_PATH/trivy fs --cache-dir=/tmp/trivy/ \
+                               --format=cyclonedx \
+                               --license-full \
+                               --no-progress \
+                               --scanners vuln \
+                               --skip-version-check \
+                               . 2>"$LOG"
+          ec=$?
+          cat "$LOG"
+          cat "$LOG" >&2
+          exit "$ec"
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/osv-scalibr-sbom/module.yaml
+++ b/scanners/boostsecurityio/osv-scalibr-sbom/module.yaml
@@ -97,7 +97,7 @@ steps:
           spdx23-json=result.spdx.json
           --plugins=sbom,sourcecode,dotnet/csproj,java/archive
           . &&
-          cat result.spdx.json 2>&1
+          cat result.spdx.json
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -23,7 +23,7 @@ setup:
             # valid rule token; do nothing
             ;;
           *)
-            echo "Semgrep Community Rules cannot be used. Provide a URL or relative path to rules file or leave blank for Boost curated rules."
+            echo "Semgrep Community Rules cannot be used. Provide a URL or relative path to rules file or leave blank for Boost curated rules." >&2
             exit 1
             ;;
         esac

--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -107,8 +107,8 @@ steps:
           --format json
           --no-progress
           --scanners ${TRIVY_SCANNERS}
-          --skip-version-check 
-          . 2>&1
+          --skip-version-check
+          .
       format: sarif
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -101,14 +101,19 @@ steps:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
           TRIVY_SCANNERS: vuln
-        run: >
-          $SETUP_PATH/trivy fs 
-          ${TRIVY_ADDITIONAL_ARGS} 
-          --format json
-          --no-progress
-          --scanners ${TRIVY_SCANNERS}
-          --skip-version-check
-          .
+        run: |
+          set +e
+          LOG=$(mktemp)
+          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} \
+                               --format json \
+                               --no-progress \
+                               --scanners ${TRIVY_SCANNERS} \
+                               --skip-version-check \
+                               . 2>"$LOG"
+          ec=$?
+          cat "$LOG"
+          cat "$LOG" >&2
+          exit "$ec"
       format: sarif
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-fs/module.yaml
+++ b/scanners/boostsecurityio/trivy-fs/module.yaml
@@ -111,8 +111,10 @@ steps:
                                --skip-version-check \
                                . 2>"$LOG"
           ec=$?
-          cat "$LOG"
-          cat "$LOG" >&2
+          # trivy's logs carry the "no language files" signal AND its fatal errors;
+          # both readers consume a different stream, so emit the logs to each:
+          cat "$LOG"      # stdout: the post-processor reads the "no language files" count here
+          cat "$LOG" >&2  # stderr: the CLI's failure telemetry only reads stderr, so errors surface
           exit "$ec"
       format: sarif
       post-processor:

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -109,8 +109,10 @@ steps:
                                --skip-version-check \
                                . 2>"$LOG"
           ec=$?
-          cat "$LOG"
-          cat "$LOG" >&2
+          # trivy's logs carry the "no language files" signal AND its fatal errors;
+          # both readers consume a different stream, so emit the logs to each:
+          cat "$LOG"      # stdout: the post-processor reads the "no language files" count here
+          cat "$LOG" >&2  # stderr: the CLI's failure telemetry only reads stderr, so errors surface
           exit "$ec"
       format: cyclonedx
       post-processor:

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -104,8 +104,8 @@ steps:
           --no-progress
           --scanners vuln
           --cache-dir=/tmp/trivy/
-          --skip-version-check 
-          . 2>&1
+          --skip-version-check
+          .
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -97,15 +97,20 @@ steps:
           NO_COLOR: "true"
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
-        run: >
-          $SETUP_PATH/trivy fs
-          --format=cyclonedx
-          --license-full
-          --no-progress
-          --scanners vuln
-          --cache-dir=/tmp/trivy/
-          --skip-version-check
-          .
+        run: |
+          set +e
+          LOG=$(mktemp)
+          $SETUP_PATH/trivy fs --format=cyclonedx \
+                               --license-full \
+                               --no-progress \
+                               --scanners vuln \
+                               --cache-dir=/tmp/trivy/ \
+                               --skip-version-check \
+                               . 2>"$LOG"
+          ec=$?
+          cat "$LOG"
+          cat "$LOG" >&2
+          exit "$ec"
       format: cyclonedx
       post-processor:
         docker:

--- a/scanners/boostsecurityio/trivy-sbom/module.yaml
+++ b/scanners/boostsecurityio/trivy-sbom/module.yaml
@@ -95,12 +95,13 @@ steps:
       command:
         environment:
           NO_COLOR: "true"
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:-}
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
         run: |
           set +e
           LOG=$(mktemp)
-          $SETUP_PATH/trivy fs --format=cyclonedx \
+          $SETUP_PATH/trivy fs ${TRIVY_ADDITIONAL_ARGS} --format=cyclonedx \
                                --license-full \
                                --no-progress \
                                --scanners vuln \


### PR DESCRIPTION
The scan CLI's failure telemetry reports a command's stderr, not stdout, so scanner failures whose error lands on stdout surface only as a bare `exited with non-zero exit status: N`. This makes those errors actionable again.

**Trivy modules (`trivy-fs`, `trivy-sbom`, `boost-sca`)** — the trivy post-processor detects "no language files" by reading trivy's `Number of language-specific files … num=0` **log line**, which reaches it only because the scan command merges stderr into stdout. Simply dropping `2>&1` would regress that (an empty report can't substitute — a clean scan can also be empty; see `no_venv`). Instead, redirect trivy's logs to a file and emit them to **both** streams, preserving the real exit code:

```sh
$SETUP_PATH/trivy fs … . 2>"$LOG"
ec=$?
cat "$LOG"        # logs -> stdout: post-processor keeps its num= detection, unchanged
cat "$LOG" >&2    # logs -> stderr: the CLI now surfaces hard failures
exit "$ec"        # preserve the exit code (do NOT force exit 0)
```

**`semgrep`** — the `Validate rules` step now echoes its rejection to stderr (`>&2`).

**`osv-scalibr-sbom`** — dropped the stray `2>&1` on `cat result.spdx.json` (its post-processor reads the SPDX file, not merged logs, so this is safe).

Validated locally (trivy 0.69.2) across: no-language-files (exit 0, `num=0` reaches the post-processor), scanned-clean, and hard failure (exit ≠ 0, real error on stderr). End-to-end dev validation via test-repo PRs to follow.

Part of boostsecurityio/workspace#79
Jira: BOOSTSP-795