### PR TITLE
Enable gitleaks decoding at depth 2 and report encoding (boostsecurityio/workspace#73)

### DIFF
--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -58,12 +58,12 @@ steps:
           GITLEAKS_CONFIG: ${GITLEAKS_CONFIG:-}
         run: |
           [ -z "$GITLEAKS_CONFIG" ] && [ -z "$GITLEAKS_CONFIG_TOML" ] && [ ! -f ".gitleaks.toml" ] && cp $SETUP_PATH/boost.toml .gitleaks.toml || true
-          $SETUP_PATH/gitleaks git --no-banner --exit-code 0 --report-format sarif --report-path $SETUP_PATH/gitleaks-output.sarif -l error .
+          $SETUP_PATH/gitleaks git --no-banner --exit-code 0 --report-format sarif --report-path $SETUP_PATH/gitleaks-output.sarif -l error --max-decode-depth=2 .
           cat $SETUP_PATH/gitleaks-output.sarif
       post-processor:
         - docker:
             command: process --git-scan
-            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-gitleaks:ff4b104@sha256:7d640ad96bf86fb1f3bd7d57deb71bcc98ad850cbdc7d9d10c865ca873715af7
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:f89b028@sha256:d6cf4b5d492401843aadcff6f0f7e19c399e5dea3a3192a8b5c0df4fa819cb0b
         - docker:
             command: process --gitleaks-full
             image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-keyscope:458e3dd@sha256:6b611b085271e2c8ed15590f536fd4a29221a11752ef7525bbb60be9ad241902

--- a/scanners/boostsecurityio/gitleaks-full/module.yaml
+++ b/scanners/boostsecurityio/gitleaks-full/module.yaml
@@ -63,7 +63,7 @@ steps:
       post-processor:
         - docker:
             command: process --git-scan
-            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:f89b028@sha256:d6cf4b5d492401843aadcff6f0f7e19c399e5dea3a3192a8b5c0df4fa819cb0b
+            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-gitleaks:3317798@sha256:c5c0234223df2c08171a6c01f15e45870a841e5a5e84c09e535981baf6ab8d0a
         - docker:
             command: process --gitleaks-full
             image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-keyscope:458e3dd@sha256:6b611b085271e2c8ed15590f536fd4a29221a11752ef7525bbb60be9ad241902

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -62,7 +62,7 @@ steps:
       post-processor:
         - docker:
             command: process
-            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:f89b028@sha256:d6cf4b5d492401843aadcff6f0f7e19c399e5dea3a3192a8b5c0df4fa819cb0b
+            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-gitleaks:3317798@sha256:c5c0234223df2c08171a6c01f15e45870a841e5a5e84c09e535981baf6ab8d0a
         - docker:
             command: process
             image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-keyscope:458e3dd@sha256:6b611b085271e2c8ed15590f536fd4a29221a11752ef7525bbb60be9ad241902

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -57,12 +57,12 @@ steps:
           GITLEAKS_CONFIG: ${GITLEAKS_CONFIG:-}
         run: |
           [ -z "$GITLEAKS_CONFIG" ] && [ -z "$GITLEAKS_CONFIG_TOML" ] && [ ! -f ".gitleaks.toml" ] && cp $SETUP_PATH/boost.toml .gitleaks.toml || true
-          $SETUP_PATH/gitleaks dir --no-banner --exit-code 0 --report-format sarif --report-path $SETUP_PATH/gitleaks-output.sarif -l error .
+          $SETUP_PATH/gitleaks dir --no-banner --exit-code 0 --report-format sarif --report-path $SETUP_PATH/gitleaks-output.sarif -l error --max-decode-depth=2 .
           cat $SETUP_PATH/gitleaks-output.sarif
       post-processor:
         - docker:
             command: process
-            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-gitleaks:ff4b104@sha256:7d640ad96bf86fb1f3bd7d57deb71bcc98ad850cbdc7d9d10c865ca873715af7
+            image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:f89b028@sha256:d6cf4b5d492401843aadcff6f0f7e19c399e5dea3a3192a8b5c0df4fa819cb0b
         - docker:
             command: process
             image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-keyscope:458e3dd@sha256:6b611b085271e2c8ed15590f536fd4a29221a11752ef7525bbb60be9ad241902


### PR DESCRIPTION
## What

Two coordinated changes to **both** production gitleaks modules
(`boostsecurityio/gitleaks` and `boostsecurityio/gitleaks-full`):

1. **Enable decoding** — add `--max-decode-depth=2` to the gitleaks scan
   command. This makes gitleaks decode and scan base64 / hex / percent /
   unicode-encoded content up to depth 2, so nested/encoded secrets are
   surfaced as findings.
2. **Report the encoding** — bump the `boost-scanner-gitleaks`
   post-processor image to the build that parses the gitleaks decode tags
   into the SARIF `encoding` field, so the newly-detected nested secrets
   carry their encoding metadata downstream.

Both are required for "detect **and** report": the flag alone finds the
nested secrets, but they'd carry no encoding metadata until the
post-processor image is bumped.

The `boost-scanner-keyscope` post-processor image is intentionally
**unchanged** in both files.

## Post-processor image

Pinned to the production image built from `boostsec-scanner-gitleaks` `main`
(PR #34, merged):
`ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-gitleaks:3317798@sha256:c5c0234223df2c08171a6c01f15e45870a841e5a5e84c09e535981baf6ab8d0a`
— built, cosign-signed, and mirrored to ghcr through the standard
scanner-publishing path. Validated end-to-end against a repo with encoded
secrets before merge.

Part of boostsecurityio/workspace#73