### PR TITLE
Update the baseline scanner image

### DIFF
--- a/scanners/boostsecurityio/baseline/module.yaml
+++ b/scanners/boostsecurityio/baseline/module.yaml
@@ -41,7 +41,7 @@ steps:
     - scan:
         command:
           docker:
-            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-native:6b6cf90@sha256:285e3bd9b11cf47c5e28d501eca0dd70a139f8c02ec1d9a469ba69d3d77dd8f9
+            image: ghcr.io/boostsecurityio/scanner-publishing/boost-scanner-native:740d2ba@sha256:83dc303403ced9513ff8b8733d4d56c08845c967f278a3b48cbbc67b3d998673
             command: scanner scan
             workdir: /src
           name: scanner


### PR DESCRIPTION
The pinned image is the build of 6b6cf90, from before CICD-001 was reworked: it keys manifests by exact filename, so it cannot see a .NET, Haskell or Rust project at all, and it looks for a lock file only beside the manifest.

The new build teaches the rule eight more ecosystems and resolves a lock file from the repository root where the tool puts it there — a cargo or uv workspace lock, a `Directory.Packages.props`, a `cabal.project.freeze` — which is what stops it reporting every member of a workspace. Our own `boost-endpoint-cli` drops from eighteen findings to four on this image.

The digest is the ghcr build of `boostsec-scanner-native` main at 740d2ba.

Part of boostsecurityio/workspace#190
